### PR TITLE
for issue #41 and #39 and #40

### DIFF
--- a/thpp/detail/TensorGeneric.h
+++ b/thpp/detail/TensorGeneric.h
@@ -188,17 +188,17 @@ template <> struct TensorOps<Tensor<real>> {
   }
   static void _max(THTensor* values, THLongTensor* indices,
                    THTensor* t, int dim) {
-    return THTensor_(max)(values, indices, t, dim);
+    return THTensor_(max)(values, indices, t, dim, 1);
   }
   static void _min(THTensor* values, THLongTensor* indices,
                    THTensor* t, int dim) {
-    return THTensor_(min)(values, indices, t, dim);
+    return THTensor_(min)(values, indices, t, dim, 1);
   }
   static void _sum(THTensor* r, THTensor* t, int dim) {
-    return THTensor_(sum)(r, t, dim);
+    return THTensor_(sum)(r, t, dim, 1);
   }
   static void _prod(THTensor* r, THTensor* t, int dim) {
-    return THTensor_(prod)(r, t, dim);
+    return THTensor_(prod)(r, t, dim, 1);
   }
   static void _cumsum(THTensor* r, THTensor* t, int dim) {
     return THTensor_(cumsum)(r, t, dim);


### PR DESCRIPTION
this is for issue #41 #39 #40 
the torch7 had Add a keepdim parameter for reduction functions over a single dimension.For detail https://github.com/torch/torch7/commit/c5e5487075fa7c9bafcbdc9d52e114aedb2bdac3
so that commit make thpp can't compile.