### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 This project is developed internally at Facebook inside a private repository.
 Changes are periodically pushed to the open-source branch. Pull requests are


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [TH++ community profile
checklist](https://github.com/facebook/thpp/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="987" alt="screen shot 2017-12-18 at 7 24 47 am" src="https://user-images.githubusercontent.com/1114467/34113435-95c8ffba-e3c4-11e7-8b20-2c2c7a3f9473.png">
<img width="992" alt="screen shot 2017-12-18 at 7 24 55 am" src="https://user-images.githubusercontent.com/1114467/34113436-95ec479a-e3c4-11e7-81ac-5ca9853e2b7c.png">

issue:
internal task t23481323